### PR TITLE
Point to asserts fork

### DIFF
--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package spanmetricsprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
+package spanmetricsprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
 
 import (
 	"time"

--- a/processor/spanmetricsprocessor/factory.go
+++ b/processor/spanmetricsprocessor/factory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package spanmetricsprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
+package spanmetricsprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
 
 import (
 	"context"

--- a/processor/spanmetricsprocessor/go.mod
+++ b/processor/spanmetricsprocessor/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor
+module github.com/asserts/opentelemetry-collector-contrib/processor/spanmetricsprocessor
 
 go 1.18
 

--- a/processor/spanmetricsprocessor/internal/cache/cache.go
+++ b/processor/spanmetricsprocessor/internal/cache/cache.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cache // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor/internal/cache"
+package cache // import "github.com/asserts/opentelemetry-collector-contrib/processor/spanmetricsprocessor/internal/cache"
 
 import (
 	"github.com/hashicorp/golang-lru/simplelru"

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package spanmetricsprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
+package spanmetricsprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
 
 import (
 	"bytes"
@@ -34,8 +34,8 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
 
+	"github.com/asserts/opentelemetry-collector-contrib/processor/spanmetricsprocessor/internal/cache"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor/internal/cache"
 )
 
 const (

--- a/processor/tailsamplingprocessor/and_helper.go
+++ b/processor/tailsamplingprocessor/and_helper.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+package tailsamplingprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 func getNewAndPolicy(logger *zap.Logger, config *AndCfg) (sampling.PolicyEvaluator, error) {

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+package tailsamplingprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 func getNewCompositePolicy(logger *zap.Logger, config *CompositeCfg) (sampling.PolicyEvaluator, error) {

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+package tailsamplingprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
 	"time"

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+package tailsamplingprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
 	"context"

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
+module github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor
 
 go 1.18
 

--- a/processor/tailsamplingprocessor/internal/idbatcher/id_batcher.go
+++ b/processor/tailsamplingprocessor/internal/idbatcher/id_batcher.go
@@ -14,7 +14,7 @@
 
 // Package idbatcher defines a pipeline of fixed size in which the
 // elements are batches of ids.
-package idbatcher // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
+package idbatcher // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
 
 import (
 	"errors"

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/internal/sampling/and.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/internal/sampling/composite.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/internal/sampling/doc.go
+++ b/processor/tailsamplingprocessor/internal/sampling/doc.go
@@ -14,4 +14,4 @@
 
 // Package sampling contains the interfaces and data types used to implement
 // the various sampling policies.
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/internal/sampling/policy.go
+++ b/processor/tailsamplingprocessor/internal/sampling/policy.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"sync"

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"hash/fnv"

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"time"

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/internal/sampling/status_code.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"errors"

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"regexp"

--- a/processor/tailsamplingprocessor/internal/sampling/time_provider.go
+++ b/processor/tailsamplingprocessor/internal/sampling/time_provider.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"time"

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/internal/sampling/util.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package sampling // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/tailsamplingprocessor/metrics.go
+++ b/processor/tailsamplingprocessor/metrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+package tailsamplingprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
 	"go.opencensus.io/stats"

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+package tailsamplingprocessor // import "github.com/asserts/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
 	"context"


### PR DESCRIPTION
[ch14893]

Change the `go.mod` and package import references to point to asserts' fork